### PR TITLE
Support multiple captures per name

### DIFF
--- a/grok.go
+++ b/grok.go
@@ -113,6 +113,24 @@ func (g *Grok) Parse(pattern string, text string) (map[string]string, error) {
 	return captures, nil
 }
 
+// ParseToMultiMap works just like Parse, except that it allows to map multiple values to the same capture name.
+func (g* Grok) ParseToMultiMap(pattern string, text string) (map[string][]string, error) {
+	captures := make(map[string][]string)
+	cr, err := g.compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	match := cr.FindStringSubmatch(text)
+	for i, name := range cr.SubexpNames() {
+		if len(match) > 0 {
+			captures[name] = append(captures[name], match[i])
+		}
+	}
+
+	return captures, nil
+}
+
 // AddPatternsFromPath loads grok patterns from a file or files from a directory
 func (g *Grok) AddPatternsFromPath(path string) error {
 

--- a/grok.go
+++ b/grok.go
@@ -97,17 +97,14 @@ func (g *Grok) Match(pattern, text string) (bool, error) {
 
 // Parse returns a string map with captured string based on provided pattern over the text
 func (g *Grok) Parse(pattern string, text string) (map[string]string, error) {
-	captures := make(map[string]string)
-	cr, err := g.compile(pattern)
+	multiCaptures, err := g.ParseToMultiMap(pattern, text)
 	if err != nil {
-		return nil, err
+		return  nil, err
 	}
 
-	match := cr.FindStringSubmatch(text)
-	for i, name := range cr.SubexpNames() {
-		if len(match) > 0 {
-			captures[name] = match[i]
-		}
+	captures := make(map[string]string)
+	for name, capturesForName := range multiCaptures {
+		captures[name] = capturesForName[0]
 	}
 
 	return captures, nil
@@ -115,7 +112,7 @@ func (g *Grok) Parse(pattern string, text string) (map[string]string, error) {
 
 // ParseToMultiMap works just like Parse, except that it allows to map multiple values to the same capture name.
 func (g* Grok) ParseToMultiMap(pattern string, text string) (map[string][]string, error) {
-	captures := make(map[string][]string)
+	multiCaptures := make(map[string][]string)
 	cr, err := g.compile(pattern)
 	if err != nil {
 		return nil, err
@@ -124,11 +121,11 @@ func (g* Grok) ParseToMultiMap(pattern string, text string) (map[string][]string
 	match := cr.FindStringSubmatch(text)
 	for i, name := range cr.SubexpNames() {
 		if len(match) > 0 {
-			captures[name] = append(captures[name], match[i])
+			multiCaptures[name] = append(multiCaptures[name], match[i])
 		}
 	}
 
-	return captures, nil
+	return multiCaptures, nil
 }
 
 // AddPatternsFromPath loads grok patterns from a file or files from a directory

--- a/grok_test.go
+++ b/grok_test.go
@@ -125,6 +125,24 @@ func TestParse(t *testing.T) {
 	}
 }
 
+func TestParseToMultiMap(t *testing.T) {
+	g := New()
+	g.AddPatternsFromPath("./patterns")
+	res, _ := g.ParseToMultiMap("%{DAY} %{DAY} %{DAY}", "Tue Wed Fri")
+	if len(res["DAY"]) != 3 {
+		t.Fatalf("DAY should be an array of 3 elements, but is '%s'", res["DAY"])
+	}
+	if res["DAY"][0] != "Tue" {
+		t.Fatalf("DAY[0] should be 'Tue' have '%s'", res["DAY"][0])
+	}
+	if res["DAY"][1] != "Wed" {
+		t.Fatalf("DAY[1] should be 'Wed' have '%s'", res["DAY"][1])
+	}
+	if res["DAY"][2] != "Fri" {
+		t.Fatalf("DAY[2] should be 'Fri' have '%s'", res["DAY"][2])
+	}
+}
+
 func TestCaptures(t *testing.T) {
 	g := New()
 	g.AddPatternsFromPath("./patterns")


### PR DESCRIPTION
Hey there, and thanks for this really nice grok implementation!

Currently, when a Grok pattern contains several match for one name, only the last one will be returned by `g.Parse`.

In this pull request, a seconds function is introduced, that returns *every* match that occured per name. Currently, I call this method `g.ParseToMultiMap` and it returns a `map[string][]string`.

This is useful as soon as one line contains multiple instances of one information type, e.g. multiple ip adresses, multiple hostnames, multiple tags etc.pp.

Thanks for looking at this and
all the best,
Felix