### PR TITLE
Only return patterns that have a semantic

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,37 +2,37 @@
 [![Build Status](https://travis-ci.org/gemsi/grok.svg)](https://travis-ci.org/gemsi/grok)
 [![Coverage Status](https://coveralls.io/repos/gemsi/grok/badge.png?branch=master)](https://coveralls.io/r/gemsi/grok?branch=master)
 [![Documentation Status](https://readthedocs.org/projects/grok-lib-for-golang/badge/?version=latest)](https://readthedocs.org/projects/grok-lib-for-golang/?badge=latest)
-         
+
 
 # grok
-simple library to use/parse grok patterns with go
+A simple library to use/parse grok patterns in Go.
 
 # Installation
-Make sure you have the a working Go environment.
+Make sure you have a working Go environment.
 
-```go get github.com/gemsi/grok```
+```sh
+go get github.com/gemsi/grok```
 
 # Use in your project
-```import "github.com/gemsi/grok"```
-
+```go
+import "github.com/gemsi/grok"```
 
 # Example
-```
+```go
 package main
 
 import (
-	"fmt"
-
-	"github.com/gemsi/grok"
+  "fmt"
+    "github.com/gemsi/grok"
 )
 
 func main() {
-	g := grok.New()
-	values, _ := g.Parse("%{COMMONAPACHELOG}", `127.0.0.1 - - [23/Apr/2014:22:58:32 +0200] "GET /index.php HTTP/1.1" 404 207`)
+    g := grok.New()
+  values, _ := g.Parse("%{COMMONAPACHELOG}", `127.0.0.1 - - [23/Apr/2014:22:58:32 +0200] "GET /index.php HTTP/1.1" 404 207`)
 
-	for k, v := range values {
-		fmt.Printf("%+15s: %s\n", k, v)
-	}
+  for k, v := range values {
+    fmt.Printf("%+15s: %s\n", k, v)
+  }
 }
 ```
 
@@ -40,28 +40,12 @@ output:
 ```
        response: 404
           bytes: 207
-               : 207
-       HOSTNAME: 127.0.0.1
-       USERNAME: -
-       MONTHDAY: 23
         request: /index.php
-      BASE10NUM: 207
-           IPV6: 
            auth: -
       timestamp: 23/Apr/2014:22:58:32 +0200
            verb: GET
     httpversion: 1.1
-           TIME: 22:58:32
-           HOUR: 22
-COMMONAPACHELOG: 127.0.0.1 - - [23/Apr/2014:22:58:32 +0200] "GET /index.php HTTP/1.1" 404 207
        clientip: 127.0.0.1
-             IP: 
           ident: -
-          MONTH: Apr
-           YEAR: 2014
-         SECOND: 32
-            INT: +0200
-           IPV4: 
-         MINUTE: 58
-     rawrequest: 
+     rawrequest:
 ```

--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ A simple library to use/parse grok patterns in Go.
 Make sure you have a working Go environment.
 
 ```sh
-go get github.com/gemsi/grok```
+go get github.com/gemsi/grok
+```
 
 # Use in your project
 ```go
-import "github.com/gemsi/grok"```
+import "github.com/gemsi/grok"
+```
 
 # Example
 ```go

--- a/grok_test.go
+++ b/grok_test.go
@@ -119,15 +119,15 @@ func TestErrorCaptureUnknowPattern(t *testing.T) {
 func TestParse(t *testing.T) {
 	g := New()
 	g.AddPatternsFromPath("./patterns")
-	res, _ := g.Parse("%{DAY}", "Tue qds")
-	if res["DAY"] != "Tue" {
-		t.Fatalf("DAY should be 'Tue' have '%s'", res["DAY"])
+	res, _ := g.Parse("%{DAY:day}", "Tue qds")
+	if res["day"] != "Tue" {
+		t.Fatalf("DAY should be 'Tue' have '%s'", res["day"])
 	}
 }
 
 func TestErrorParseToMultiMap(t *testing.T) {
 	g := New()
-	pattern := "%{UNKNOWPATTERN}"
+	pattern := "%{UNKNOWNPATTERN:up}"
 	_, err := g.ParseToMultiMap(pattern, "")
 	if err == nil {
 		t.Fatal("Expected error not set")
@@ -137,18 +137,18 @@ func TestErrorParseToMultiMap(t *testing.T) {
 func TestParseToMultiMap(t *testing.T) {
 	g := New()
 	g.AddPatternsFromPath("./patterns")
-	res, _ := g.ParseToMultiMap("%{DAY} %{DAY} %{DAY}", "Tue Wed Fri")
-	if len(res["DAY"]) != 3 {
-		t.Fatalf("DAY should be an array of 3 elements, but is '%s'", res["DAY"])
+	res, _ := g.ParseToMultiMap("%{DAY:day} %{DAY:day} %{DAY:day}", "Tue Wed Fri")
+	if len(res["day"]) != 3 {
+		t.Fatalf("day[] should be an array of 3 elements, but is '%s'", res["day"])
 	}
-	if res["DAY"][0] != "Tue" {
-		t.Fatalf("DAY[0] should be 'Tue' have '%s'", res["DAY"][0])
+	if res["day"][0] != "Tue" {
+		t.Fatalf("day[0] should be 'Tue' have '%s'", res["DAY"][0])
 	}
-	if res["DAY"][1] != "Wed" {
-		t.Fatalf("DAY[1] should be 'Wed' have '%s'", res["DAY"][1])
+	if res["day"][1] != "Wed" {
+		t.Fatalf("day[1] should be 'Wed' have '%s'", res["DAY"][1])
 	}
-	if res["DAY"][2] != "Fri" {
-		t.Fatalf("DAY[2] should be 'Fri' have '%s'", res["DAY"][2])
+	if res["day"][2] != "Fri" {
+		t.Fatalf("day[2] should be 'Fri' have '%s'", res["DAY"][2])
 	}
 }
 
@@ -167,8 +167,8 @@ func TestCaptures(t *testing.T) {
 		}
 	}
 
-	check("DAY", "Tue",
-		"%{DAY}",
+	check("day", "Tue",
+		"%{DAY:day}",
 		"Tue May 15 11:21:42 [conn1047685] moveChunk deleted: 7157",
 	)
 	check("jour", "Tue",
@@ -193,29 +193,28 @@ func TestCaptures(t *testing.T) {
 	)
 
 	//PATH
-	check("WINPATH", `c:\winfows\sdf.txt`, "%{WINPATH}", `s dfqs c:\winfows\sdf.txt`)
-	check("WINPATH", `\\sdf\winfows\sdf.txt`, "%{WINPATH}", `s dfqs \\sdf\winfows\sdf.txt`)
-	check("UNIXPATH", `/usr/lib/`, "%{UNIXPATH}", `s dfqs /usr/lib/ sqfd`)
-	check("UNIXPATH", `/usr/lib`, "%{UNIXPATH}", `s dfqs /usr/lib sqfd`)
-	check("UNIXPATH", `/usr/`, "%{UNIXPATH}", `s dfqs /usr/ sqfd`)
-	check("UNIXPATH", `/usr`, "%{UNIXPATH}", `s dfqs /usr sqfd`)
-	check("UNIXPATH", `/`, "%{UNIXPATH}", `s dfqs / sqfd`)
+	check("path", `c:\winfows\sdf.txt`, "%{WINPATH:path}", `s dfqs c:\winfows\sdf.txt`)
+	check("path", `\\sdf\winfows\sdf.txt`, "%{WINPATH:path}", `s dfqs \\sdf\winfows\sdf.txt`)
+	check("path", `/usr/lib/`, "%{UNIXPATH:path}", `s dfqs /usr/lib/ sqfd`)
+	check("path", `/usr/lib`, "%{UNIXPATH:path}", `s dfqs /usr/lib sqfd`)
+	check("path", `/usr/`, "%{UNIXPATH:path}", `s dfqs /usr/ sqfd`)
+	check("path", `/usr`, "%{UNIXPATH:path}", `s dfqs /usr sqfd`)
+	check("path", `/`, "%{UNIXPATH:path}", `s dfqs / sqfd`)
 
 	//YEAR
-	check("YEAR", `4999`, "%{YEAR}", `s d9fq4999s ../ sdf`)
-	check("YEAR", `79`, "%{YEAR}", `s d79fq4999s ../ sdf`)
-	check("TIMESTAMP_ISO8601", `2013-11-06 04:50:17,1599`, "%{TIMESTAMP_ISO8601}", `s d9fq4999s ../ sdf 2013-11-06 04:50:17,1599sd`)
+	check("year", `4999`, "%{YEAR:year}", `s d9fq4999s ../ sdf`)
+	check("year", `79`, "%{YEAR:year}", `s d79fq4999s ../ sdf`)
+	check("timestamp", `2013-11-06 04:50:17,1599`, "%{TIMESTAMP_ISO8601:timestamp}", `s d9fq4999s ../ sdf 2013-11-06 04:50:17,1599sd`)
 
 	//MAC
-	check("MAC", `01:02:03:04:ab:cf`, "%{MAC}", `s d9fq4999s ../ sdf 2013- 01:02:03:04:ab:cf  11-06 04:50:17,1599sd`)
-	check("MAC", `01-02-03-04-ab-cd`, "%{MAC}", `s d9fq4999s ../ sdf 2013- 01-02-03-04-ab-cd  11-06 04:50:17,1599sd`)
+	check("mac", `01:02:03:04:ab:cf`, "%{MAC:mac}", `s d9fq4999s ../ sdf 2013- 01:02:03:04:ab:cf  11-06 04:50:17,1599sd`)
+	check("mac", `01-02-03-04-ab-cd`, "%{MAC:mac}", `s d9fq4999s ../ sdf 2013- 01-02-03-04-ab-cd  11-06 04:50:17,1599sd`)
 
 	//QUOTEDSTRING
-	check("QUOTEDSTRING", `"lkj"`, "%{QUOTEDSTRING}", `qsdklfjqsd fk"lkj"mkj`)
-	check("QUOTEDSTRING", `'lkj'`, "%{QUOTEDSTRING}", `qsdklfjqsd fk'lkj'mkj`)
-	check("QUOTEDSTRING", `"fk'lkj'm"`, "%{QUOTEDSTRING}", `qsdklfjqsd "fk'lkj'm"kj`)
-	check("QUOTEDSTRING", `'fk"lkj"m'`, "%{QUOTEDSTRING}", `qsdklfjqsd 'fk"lkj"m'kj`)
-
+	check("qs", `"lkj"`, "%{QUOTEDSTRING:qs}", `qsdklfjqsd fk"lkj"mkj`)
+	check("qs", `'lkj'`, "%{QUOTEDSTRING:qs}", `qsdklfjqsd fk'lkj'mkj`)
+	check("qs", `"fk'lkj'm"`, "%{QUOTEDSTRING:qs}", `qsdklfjqsd "fk'lkj'm"kj`)
+	check("qs", `'fk"lkj"m'`, "%{QUOTEDSTRING:qs}", `qsdklfjqsd 'fk"lkj"m'kj`)
 }
 
 // Should be run with -race
@@ -234,9 +233,9 @@ func TestConcurentParse(t *testing.T) {
 		}
 	}
 
-	go check("QUOTEDSTRING", `"lkj"`, "%{QUOTEDSTRING}", `qsdklfjqsd fk"lkj"mkj`)
-	go check("QUOTEDSTRING", `'lkj'`, "%{QUOTEDSTRING}", `qsdklfjqsd fk'lkj'mkj`)
-	go check("QUOTEDSTRING", `'lkj'`, "%{QUOTEDSTRING}", `qsdklfjqsd fk'lkj'mkj`)
-	go check("QUOTEDSTRING", `"fk'lkj'm"`, "%{QUOTEDSTRING}", `qsdklfjqsd "fk'lkj'm"kj`)
-	go check("QUOTEDSTRING", `'fk"lkj"m'`, "%{QUOTEDSTRING}", `qsdklfjqsd 'fk"lkj"m'kj`)
+	go check("qs", `"lkj"`, "%{QUOTEDSTRING:qs}", `qsdklfjqsd fk"lkj"mkj`)
+	go check("qs", `'lkj'`, "%{QUOTEDSTRING:qs}", `qsdklfjqsd fk'lkj'mkj`)
+	go check("qs", `'lkj'`, "%{QUOTEDSTRING:qs}", `qsdklfjqsd fk'lkj'mkj`)
+	go check("qs", `"fk'lkj'm"`, "%{QUOTEDSTRING:qs}", `qsdklfjqsd "fk'lkj'm"kj`)
+	go check("qs", `'fk"lkj"m'`, "%{QUOTEDSTRING:qs}", `qsdklfjqsd 'fk"lkj"m'kj`)
 }

--- a/grok_test.go
+++ b/grok_test.go
@@ -183,10 +183,6 @@ func TestCaptures(t *testing.T) {
 		"%{COMMONAPACHELOG}",
 		`127.0.0.1 - - [23/Apr/2014:22:58:32 +0200] "GET /index.php HTTP/1.1" 404 207`,
 	)
-	check("TIME", "22:58:32",
-		"%{COMMONAPACHELOG}",
-		`127.0.0.1 - - [23/Apr/2014:22:58:32 +0200] "GET /index.php HTTP/1.1" 404 207`,
-	)
 	check("timestamp", "23/Apr/2014:22:58:32 +0200",
 		"%{COMMONAPACHELOG}",
 		`127.0.0.1 - - [23/Apr/2014:22:58:32 +0200] "GET /index.php HTTP/1.1" 404 207`,
@@ -209,7 +205,6 @@ func TestCaptures(t *testing.T) {
 	check("YEAR", `4999`, "%{YEAR}", `s d9fq4999s ../ sdf`)
 	check("YEAR", `79`, "%{YEAR}", `s d79fq4999s ../ sdf`)
 	check("TIMESTAMP_ISO8601", `2013-11-06 04:50:17,1599`, "%{TIMESTAMP_ISO8601}", `s d9fq4999s ../ sdf 2013-11-06 04:50:17,1599sd`)
-	check("SECOND", `17,1599`, "%{TIMESTAMP_ISO8601}", `s d9fq4999s ../ sdf 2013-11-06 04:50:17,1599sd`)
 
 	//MAC
 	check("MAC", `01:02:03:04:ab:cf`, "%{MAC}", `s d9fq4999s ../ sdf 2013- 01:02:03:04:ab:cf  11-06 04:50:17,1599sd`)


### PR DESCRIPTION
I've made some changes that makes this package behave a bit more like logstash, in that it now only returns patterns that have a semantic from the Grok.Parse() and Grok.ParseToMultiMap() functions. 

For instance, where your example code used to return:

```
       response: 404
          bytes: 207
               : 207
       HOSTNAME: 127.0.0.1
       USERNAME: -
       MONTHDAY: 23
        request: /index.php
      BASE10NUM: 207
           IPV6: 
           auth: -
      timestamp: 23/Apr/2014:22:58:32 +0200
           verb: GET
    httpversion: 1.1
           TIME: 22:58:32
           HOUR: 22
COMMONAPACHELOG: 127.0.0.1 - - [23/Apr/2014:22:58:32 +0200] "GET /index.php HTTP/1.1" 404 207
       clientip: 127.0.0.1
             IP: 
          ident: -
          MONTH: Apr
           YEAR: 2014
         SECOND: 32
            INT: +0200
           IPV4: 
         MINUTE: 58
     rawrequest: 
```

It now returns:

```
       response: 404
          bytes: 207
        request: /index.php
           auth: -
      timestamp: 23/Apr/2014:22:58:32 +0200
           verb: GET
    httpversion: 1.1
       clientip: 127.0.0.1
          ident: -
     rawrequest:
```