### PR TITLE
Task/refactor parse typed

### DIFF
--- a/grok_test.go
+++ b/grok_test.go
@@ -454,14 +454,14 @@ func TestParseTypedWithDefaultCaptureMode(t *testing.T) {
 
 func TestParseTypedWithNoTypeInfo(t *testing.T) {
 	g := NewWithConfig(&Config{NamedCapturesOnly: true})
-	if captures, err := g.Parse("%{COMMONAPACHELOG}", `127.0.0.1 - - [23/Apr/2014:22:58:32 +0200] "GET /index.php HTTP/1.1" 404 207`); err != nil {
+	if captures, err := g.ParseTyped("%{COMMONAPACHELOG}", `127.0.0.1 - - [23/Apr/2014:22:58:32 +0200] "GET /index.php HTTP/1.1" 404 207`); err != nil {
 		t.Fatalf("error can not capture : %s", err.Error())
 	} else {
 		if captures["timestamp"] != "23/Apr/2014:22:58:32 +0200" {
 			t.Fatalf("%s should be '%s' have '%s'", "timestamp", "23/Apr/2014:22:58:32 +0200", captures["timestamp"])
 		}
-		if captures["TIME"] != "" {
-			t.Fatalf("%s should be '%s' have '%s'", "TIME", "", captures["TIME"])
+		if captures["TIME"] != nil {
+			t.Fatalf("%s should be '%s' have '%s'", "TIME", nil, captures["TIME"])
 		}
 	}
 


### PR DESCRIPTION
When parsing grok segments, if typing information is available (%{NUMBER:code:int}), it is stored in new Grok.typeInfo field for later use. That typing data is used for returning type-enabled JSON objects when calling Grok.ParseTyped

Added 3 main test suites for testing happy paths:

- TestParseTypedWithNoTypeInfo. Copied from existing TestParseWithDefaultCaptureMode and replacing type-unaware Parse call with type-aware ParseTyped function. This tests guarantees using ParseTyped with no typing information is equivalent to calling to Parse.

- TestParseTypedWithDefaultCaptureMode. Tests castings to float, int and string when type information is passed in grok segments.

- TestParseTypedWithIntegerTypeCoercion. Testing casting coertions between float and int.

Added 2 extra test cases for testing error flows (reaching 100% code coverage)